### PR TITLE
internal service port changed to 17121

### DIFF
--- a/src/js/ws_config.js
+++ b/src/js/ws_config.js
@@ -20,7 +20,7 @@ config.walletServiceBinaryFilename = 'nibble-service';
 config.walletServiceBinaryVersion = "v1.0.0";
 
 // default port number for your wallet service (e.g. turtle-service)
-config.walletServiceRpcPort = 8070;
+config.walletServiceRpcPort = 17121;
 
 // block explorer url, the [[TX_HASH] will be substituted w/ actual transaction hash
 config.blockExplorerUrl = 'https://nbx.cryptonight.mine.nu/explorer/?hash=[[TX_HASH]]#blockchain_transaction';

--- a/src/js/ws_manager.js
+++ b/src/js/ws_manager.js
@@ -152,7 +152,8 @@ WalletShellManager.prototype.startService = function(walletFile, password, onErr
     let serviceArgs = this.serviceArgsDefault.concat([
         '-w', walletFile,
         '-p', password,
-        '--log-level', 0,
+        '--bind-port', 17121, 
+	'--log-level', 0,
         '--address'
     ]);
 
@@ -202,7 +203,8 @@ WalletShellManager.prototype._spawnService = function(walletFile, password, onEr
         '--container-file', walletFile,
         '--container-password', password,
         '--enable-cors', '*',
-        '--daemon-address', this.daemonHost,
+        '--bind-port', 17121, 
+	'--daemon-address', this.daemonHost,
         '--daemon-port', this.daemonPort,
         '--log-level', SERVICE_LOG_LEVEL
     ]);


### PR DESCRIPTION
Changed service default port for nibble-service from 8070 to 17121 , to prevent conflicts with TRTL